### PR TITLE
[...] add macOS ("osx") to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ node_js:
 os:
   - linux
   - windows
-  # FUTURE TBD:
-  # - osx
+  - osx


### PR DESCRIPTION
Travis CI testing on macOS is desired. Unfortunately it seems to go through the Travis CI queue very slowly.