### PR TITLE
[WIP] general cleanup fixes in `lib/program-helper.js`

### DIFF
--- a/lib/program-helper.js
+++ b/lib/program-helper.js
@@ -49,20 +49,6 @@ function resolveGlobs() {
 }
 
 /**
- * Check if a file exists
- * @param cmdPath
- * @returns {boolean}
- */
-function fileExists(cmdPath) {
-    try {
-        fs.accessSync(cmdPath, fs.constants.F_OK);
-        return true;
-    } catch (e) {
-        return false;
-    }
-}
-
-/**
  * Find tsc file executable path - exported
  *
  * @returns {string}

--- a/lib/program-helper.js
+++ b/lib/program-helper.js
@@ -1,20 +1,22 @@
-#!/usr/bin/env node
-
 /**
  * @typedef {import('commander').Command} Command
  */
 
+const fs = require('fs');
+const path = require('path');
+
+const commander = require('commander');
+
 const execa = require('execa');
 
-const glob = require('glob'),
-    fs = require('fs'),
-    path = require('path')
+const glob = require('glob');
 
 /**
  * Throw error and stop process.
  */
 function error() {
-    var args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(arguments);
+
     throw ['ERROR:', args.join(' ')].join(' ')
 }
 
@@ -23,17 +25,17 @@ function error() {
  * @returns {Array}
  */
 function resolveGlobs() {
-    var options = Helper.getOptions(),
-        tsConfigFile,
-        tsConfig;
+    const options = getOptions();
 
     if (options['filesGlob'] && options['filesGlob'].length) {
         return options['filesGlob'];
     } else {
-        tsConfigFile = path.join(process.cwd(), options['tsconfigFile']);
+        const tsConfigFile = path.join(process.cwd(), options['tsconfigFile']);
+
         try {
             fs.accessSync(tsConfigFile, fs.constants.R_OK);
-            tsConfig = require(tsConfigFile);
+
+            const tsConfig = require(tsConfigFile);
 
             if (!tsConfig['filesGlob'] || !(tsConfig['filesGlob'] instanceof Array)) {
                 error('Property "filesGlob" not found in tsconfig.json');
@@ -60,14 +62,12 @@ function fileExists(cmdPath) {
     }
 }
 
-var Helper = {};
-
 /**
- * Find tsc file executable path
+ * Find tsc file executable path - exported
  *
  * @returns {string}
  */
-Helper.getTSCCommand = function () {
+function getTSCCommand () {
     // NOTE: This will throw an error if no valid tsc CLI program is found.
     // FUTURE TODO: show more descriptive error and test it in the test suite
     console.info('checking for valid `tsc` CLI program');
@@ -78,12 +78,12 @@ Helper.getTSCCommand = function () {
 };
 
 /**
- * Resolve ts file paths
+ * Resolve ts file paths - exported
  *
  * @returns {Array}
  */
-Helper.resolveTSFiles = function () {
-    var files = [];
+function resolveTSFiles () {
+    const files = [];
 
     resolveGlobs().forEach(function (pattern) {
         glob.sync(pattern).forEach(function (file) {
@@ -95,11 +95,11 @@ Helper.resolveTSFiles = function () {
 };
 
 /**
- * Get command options
+ * Get command options - exported
  * @returns {Command}
  */
-Helper.getOptions = function () {
-    var commander = require('commander')
+function getOptions () {
+    const program = commander
         .command('glob-tsc')
         .version(require('../package.json').version)
         .usage('[options]')
@@ -109,9 +109,13 @@ Helper.getOptions = function () {
             return val.split(',');
         }, []).parse(process.argv);
 
-    commander.unknown = commander.parseOptions(process.argv).unknown;
+    program.unknown = program.parseOptions(process.argv).unknown;
 
-    return commander;
+    return program;
 };
 
-module.exports = Helper;
+module.exports = {
+    getOptions,
+    getTSCCommand,
+    resolveTSFiles
+};

--- a/lib/program-helper.js
+++ b/lib/program-helper.js
@@ -15,9 +15,9 @@ const glob = require('glob');
  * Throw error and stop process.
  */
 function error() {
-    const args = Array.prototype.slice.call(arguments);
-
-    throw ['ERROR:', args.join(' ')].join(' ')
+    throw ['ERROR:'].concat(
+        Array.prototype.slice.call(arguments)
+    ).join(' ');
 }
 
 /**


### PR DESCRIPTION
- remove shebang line
- keep all require statements as const statements, in the beginning of the module
- use const instead of var
- minor spacing improvements
- fix module exports to export named functions
- use correct name for the commander program object in the `getOptions` function