### PR TITLE
Fixed checkjs problems.

### DIFF
--- a/lib/program-helper.js
+++ b/lib/program-helper.js
@@ -4,18 +4,17 @@
  * @typedef {import('commander').Command} Command
  */
 
-const execa = require('execa');
-
-const glob = require('glob'),
+const execa = require('execa'),
+    glob = require('glob'),
     fs = require('fs'),
-    path = require('path')
+    path = require('path');
 
 /**
  * Throw error and stop process.
  */
 function error() {
     var args = Array.prototype.slice.call(arguments);
-    throw ['ERROR:', args.join(' ')].join(' ')
+    throw ['ERROR:', args.join(' ')].join(' ');
 }
 
 /**
@@ -60,58 +59,67 @@ function fileExists(cmdPath) {
     }
 }
 
-var Helper = {};
-
 /**
- * Find tsc file executable path
- *
- * @returns {string}
+ * @typedef {object} HelperType
+ * @prop {() => string} getTSCCommand
+ * @prop {() => string[]} resolveTSFiles
+ * @prop {() => Command} getOptions
  */
-Helper.getTSCCommand = function () {
-    // NOTE: This will throw an error if no valid tsc CLI program is found.
-    // FUTURE TODO: show more descriptive error and test it in the test suite
-    console.info('checking for valid `tsc` CLI program');
-    execa.commandSync('tsc --version', { stdio: 'inherit' });
-    console.info('valid `tsc` CLI program found');
 
-    return 'tsc';
-};
+/** @type {HelperType} */
+var Helper = {
+    /**
+     * Find tsc file executable path
+     *
+     * @returns {string}
+     */
+    getTSCCommand: function () {
+        // NOTE: This will throw an error if no valid tsc CLI program is found.
+        // FUTURE TODO: show more descriptive error and test it in the test suite
+        console.info('checking for valid `tsc` CLI program');
+        execa.commandSync('tsc --version', { stdio: 'inherit' });
+        console.info('valid `tsc` CLI program found');
 
-/**
- * Resolve ts file paths
- *
- * @returns {Array}
- */
-Helper.resolveTSFiles = function () {
-    var files = [];
+        return 'tsc';
+    },
 
-    resolveGlobs().forEach(function (pattern) {
-        glob.sync(pattern).forEach(function (file) {
-            files.push(file);
+    /**
+     * Resolve ts file paths
+     *
+     * @returns {Array}
+     */
+    resolveTSFiles: function () {
+        var files = [];
+
+        resolveGlobs().forEach(function (pattern) {
+            glob.sync(pattern).forEach(function (file) {
+                files.push(file);
+            });
         });
-    });
 
-    return files
+        return files
+    },
+
+    /**
+     * Get command options
+     * @returns {Command}
+     */
+    getOptions: function () {
+        var commander = require('commander')
+            .command('glob-tsc')
+            .version(require('../package.json').version)
+            .usage('[options]')
+            .allowUnknownOption(true)
+            .option('-f, --tsconfig-file <path>', 'tsconfig.json file location. Default ./tsconfig.json', 'tsconfig.json')
+            .option('-g, --files-glob <globs>', 'File globs', function (val) {
+                return val.split(',');
+            }, []).parse(process.argv);
+
+        commander.unknown = commander.parseOptions(process.argv).unknown;
+
+        return commander;
+    }
 };
 
-/**
- * Get command options
- * @returns {Command}
- */
-Helper.getOptions = function () {
-    var commander = require('commander')
-        .command('glob-tsc')
-        .version(require('../package.json').version)
-        .usage('[options]')
-        .allowUnknownOption(true)
-        .option('-f, --tsconfig-file <path>', 'tsconfig.json file location. Default ./tsconfig.json', 'tsconfig.json')
-        .option('-g, --files-glob <globs>', 'File globs', function (val) {
-            return val.split(',');
-        }, []).parse(process.argv);
-
-    commander.unknown = commander.parseOptions(process.argv).unknown;
-
-    return commander;
-};
 
 module.exports = Helper;

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "npm-run-all": "^4.1.5",
     "typescript": "^3.6.4"
   },
-  "peerDependencies": {
-    "typescript": "^3.0.0"
-  },
   "dependencies": {
     "commander": "^3.0.2",
     "cross-spawn": "^7.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "lib/program-helper.js"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
1. Added tsconfig to handle TypeScript options.
2. Removed statel peerDenencies since TypeScript was alread in devDependencies.
3. Refactored Helper as a single object literal declaration with methods. Attaching methods as static properties results in TypeScript errors due to inability of TypeScrpit to understand JavaScript expando properties.