### PR TITLE
add Stryker mutator testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ coverage
 node_modules
 package-lock.json
 yarn.lock
+.stryker-tmp
+reports

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "checkjs": "node bin/glob-tsc.js --allowJs --checkJs --noEmit --resolveJsonModule --target es5 -g bin/**/*.js,test/**/*.js",
+    "stryker": "stryker run",
     "test": "npm-run-all checkjs test:mocha",
     "test:mocha": "mocha --timeout 5000",
     "test:watch": "_mocha --watch"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "license": "ISC",
   "devDependencies": {
     "@stryker-mutator/core": "^2.1.0",
+    "@stryker-mutator/html-reporter": "^2.1.0",
+    "@stryker-mutator/javascript-mutator": "^2.1.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.11.7",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "@stryker-mutator/core": "^2.1.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.11.7",
     "chai": "^4.2.0",

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,0 +1,10 @@
+module.exports = function(config) {
+  config.set({
+    mutator: "javascript",
+    packageManager: "yarn",
+    reporters: ["html", "clear-text", "progress"],
+    testRunner: "command",
+    transpilers: [],
+    coverageAnalysis: "all"
+  });
+};

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -1,5 +1,6 @@
 module.exports = function(config) {
   config.set({
+    mutate: ["bin/**/*.js", "lib/**/*.js"],
     mutator: "javascript",
     packageManager: "yarn",
     reporters: ["html", "clear-text", "progress"],


### PR DESCRIPTION
start mutation testing using [Stryker mutator](http://stryker-mutator.io/) as discussed in #8

with initial mutation report here: https://chrisbrody.com/glob-tsc-mutation

Unfortunately Styker seems to require specification of npm vs Yarn package manager. I am using Yarn for Stryker (and other development tasks) since it seems to work a little more smoothly than `npm`.

P.S. Another issue was that I had trouble with specifying "mocha" as the test runner, specified "command" as the test runner instead. This does have a bonus that it would be broken by switching to Jest, for example.

/cc @rbiggs