### PR TITLE
Added proper types for Helper Object and its methods.

### DIFF
--- a/lib/program-helper.js
+++ b/lib/program-helper.js
@@ -59,13 +59,17 @@ function fileExists(cmdPath) {
         return false;
     }
 }
-
+/**
+ * @typedef {Object} HelperType
+ * @prop {() => string} getTSCCommand
+ * @prop {() => string[]} resolveTSFiles
+ * @prop {() => Command} getOptions
+ */
+/** @type {HelperType} */
 var Helper = {};
 
 /**
  * Find tsc file executable path
- *
- * @returns {string}
  */
 Helper.getTSCCommand = function () {
     // NOTE: This will throw an error if no valid tsc CLI program is found.
@@ -79,8 +83,6 @@ Helper.getTSCCommand = function () {
 
 /**
  * Resolve ts file paths
- *
- * @returns {Array}
  */
 Helper.resolveTSFiles = function () {
     var files = [];
@@ -96,7 +98,6 @@ Helper.resolveTSFiles = function () {
 
 /**
  * Get command options
- * @returns {Command}
  */
 Helper.getOptions = function () {
     var commander = require('commander')


### PR DESCRIPTION
This is a simpler fix for you checkjs problem. Just needed to define the HelperType object with its methods and return types and then cast the Helper object to that type.