### PR TITLE
lib cleanup: fix exported Helper object

### DIFF
--- a/lib/program-helper.js
+++ b/lib/program-helper.js
@@ -22,7 +22,7 @@ function error() {
  * @returns {Array}
  */
 function resolveGlobs() {
-    var options = Helper.getOptions(),
+    var options = getOptions(),
         tsConfigFile,
         tsConfig;
 
@@ -59,14 +59,12 @@ function fileExists(cmdPath) {
     }
 }
 
-var Helper = {};
-
 /**
- * Find tsc file executable path
+ * Find tsc file executable path - exported
  *
  * @returns {string}
  */
-Helper.getTSCCommand = function () {
+function getTSCCommand () {
     // NOTE: This will throw an error if no valid tsc CLI program is found.
     // FUTURE TODO: show more descriptive error and test it in the test suite
     console.info('checking for valid `tsc` CLI program');
@@ -77,11 +75,11 @@ Helper.getTSCCommand = function () {
 };
 
 /**
- * Resolve ts file paths
+ * Resolve ts file paths - exported
  *
  * @returns {Array}
  */
-Helper.resolveTSFiles = function () {
+function resolveTSFiles () {
     var files = [];
 
     resolveGlobs().forEach(function (pattern) {
@@ -94,10 +92,10 @@ Helper.resolveTSFiles = function () {
 };
 
 /**
- * Get command options
+ * Get command options - exported
  * @returns {Command}
  */
-Helper.getOptions = function () {
+function getOptions () {
     var commander = require('commander')
         .command('glob-tsc')
         .version(require('../package.json').version)
@@ -113,4 +111,8 @@ Helper.getOptions = function () {
     return commander;
 };
 
-module.exports = Helper;
+module.exports = {
+    getOptions,
+    getTSCCommand,
+    resolveTSFiles
+};


### PR DESCRIPTION
This would very likely affect where we use the declared Helper object type proposed in PR #14.

/cc @rbiggs - I would appreciate some feedback on this proposal.

These changes would be moved out of PR #9.